### PR TITLE
Improve -default-mouse-move-global efficiency

### DIFF
--- a/src/membrane/ui.cljc
+++ b/src/membrane/ui.cljc
@@ -158,20 +158,12 @@
   (-bubble [elem effects]
     nil))
 
-
-
 (defn -default-mouse-move-global [elem offset]
   (let [[ox oy] (origin elem)
         [sx sy] offset
         child-offset [(- sx ox)
                       (- sy oy)]]
-    (let [intents
-          (reduce into
-                  []
-                  (for [child (children elem)]
-                    (-mouse-move-global child child-offset)))]
-      (-bubble elem intents))))
-
+    (-bubble elem (into [] (mapcat #(-mouse-move-global % child-offset)) (children elem)))))
 
 (declare bounds)
 


### PR DESCRIPTION
Instead of bashing on the same vector with into and going through laziness, this refactor uses into's transducer arity to allocate only a single vector per call